### PR TITLE
Add the resume download for downloading script

### DIFF
--- a/download_raw_data.sh
+++ b/download_raw_data.sh
@@ -1,1 +1,1 @@
-cat raw_data_urls.txt | xargs -n 1 -P 6 wget -P data/
+cat raw_data_urls.txt | xargs -n 1 -P 6 wget -c -P data/

--- a/download_raw_uber_data.sh
+++ b/download_raw_uber_data.sh
@@ -1,1 +1,1 @@
-cat raw_uber_data_urls.txt | xargs -n 1 -P 6 wget -P data/
+cat raw_uber_data_urls.txt | xargs -n 1 -P 6 wget -c -P data/


### PR DESCRIPTION
This is useful when we want to finish a download started by a previous instance of wget. For instance,  if my internet connection times out for some reason, the wget process will automatically resume from where it was interrupted.