### PR TITLE
Add pickup and dropoff location IDs to trips

### DIFF
--- a/add_tract_to_zone_mapping.sql
+++ b/add_tract_to_zone_mapping.sql
@@ -1,0 +1,11 @@
+CREATE TABLE nyct2010_taxi_zones_mapping AS
+SELECT
+  ct.gid AS nyct2010_gid,
+  tz.locationid AS taxi_zone_location_id,
+  ST_Area(ST_Intersection(ct.geom, tz.geom)) / ST_Area(ct.geom) AS overlap
+FROM nyct2010 ct, taxi_zones tz
+WHERE ST_Intersects(ct.geom, tz.geom)
+  AND ST_Area(ST_Intersection(ct.geom, tz.geom)) / ST_Area(ct.geom) > 0.5;
+
+CREATE UNIQUE INDEX index_mapping_on_tract_unique ON nyct2010_taxi_zones_mapping (nyct2010_gid);
+CREATE INDEX index_mapping_on_tract_and_zone ON nyct2010_taxi_zones_mapping (nyct2010_gid, taxi_zone_location_id);

--- a/initialize_database.sh
+++ b/initialize_database.sh
@@ -15,6 +15,8 @@ psql nyc-taxi-data -c "CREATE INDEX index_nyct_on_geom ON nyct2010 USING gist (g
 psql nyc-taxi-data -c "CREATE INDEX index_nyct_on_ntacode ON nyct2010 (ntacode);"
 psql nyc-taxi-data -c "VACUUM ANALYZE nyct2010;"
 
+psql nyc-taxi-data -f add_tract_to_zone_mapping.sql
+
 cat data/fhv_bases.csv | psql nyc-taxi-data -c "COPY fhv_bases FROM stdin WITH CSV HEADER;"
 cat data/central_park_weather.csv | psql nyc-taxi-data -c "COPY central_park_weather_observations FROM stdin WITH CSV HEADER;"
 psql nyc-taxi-data -c "UPDATE central_park_weather_observations SET average_wind_speed = NULL WHERE average_wind_speed = -9999;"

--- a/populate_green_trips.sql
+++ b/populate_green_trips.sql
@@ -54,13 +54,15 @@ SELECT
   END,
   tmp_pickups.gid,
   tmp_dropoffs.gid,
-  pickup_location_id::integer,
-  dropoff_location_id::integer
+  COALESCE(pickup_location_id::integer, map_pickups.taxi_zone_location_id),
+  COALESCE(dropoff_location_id::integer, map_dropoffs.taxi_zone_location_id)
 FROM
   green_tripdata_staging
     INNER JOIN cab_types ON cab_types.type = 'green'
     LEFT JOIN tmp_pickups ON green_tripdata_staging.id = tmp_pickups.id
-    LEFT JOIN tmp_dropoffs ON green_tripdata_staging.id = tmp_dropoffs.id;
+      LEFT JOIN nyct2010_taxi_zones_mapping map_pickups ON tmp_pickups.gid = map_pickups.nyct2010_gid
+    LEFT JOIN tmp_dropoffs ON green_tripdata_staging.id = tmp_dropoffs.id
+      LEFT JOIN nyct2010_taxi_zones_mapping map_dropoffs ON tmp_dropoffs.gid = map_dropoffs.nyct2010_gid;
 
 TRUNCATE TABLE green_tripdata_staging;
 DROP TABLE tmp_points;

--- a/populate_yellow_trips.sql
+++ b/populate_yellow_trips.sql
@@ -52,13 +52,15 @@ SELECT
   END,
   tmp_pickups.gid,
   tmp_dropoffs.gid,
-  pickup_location_id::integer,
-  dropoff_location_id::integer
+  COALESCE(pickup_location_id::integer, map_pickups.taxi_zone_location_id),
+  COALESCE(dropoff_location_id::integer, map_dropoffs.taxi_zone_location_id)
 FROM
   yellow_tripdata_staging
     INNER JOIN cab_types ON cab_types.type = 'yellow'
     LEFT JOIN tmp_pickups ON yellow_tripdata_staging.id = tmp_pickups.id
-    LEFT JOIN tmp_dropoffs ON yellow_tripdata_staging.id = tmp_dropoffs.id;
+      LEFT JOIN nyct2010_taxi_zones_mapping map_pickups ON tmp_pickups.gid = map_pickups.nyct2010_gid
+    LEFT JOIN tmp_dropoffs ON yellow_tripdata_staging.id = tmp_dropoffs.id
+      LEFT JOIN nyct2010_taxi_zones_mapping map_dropoffs ON tmp_dropoffs.gid = map_dropoffs.nyct2010_gid;
 
 TRUNCATE TABLE yellow_tripdata_staging;
 DROP TABLE tmp_points;


### PR DESCRIPTION
TLC stopped providing lat/long in July 2016. Now they provide taxi zone location IDs for pickups and dropoffs. Add comparable location IDs to historical trips