### PR TITLE
Update with urls from first half of 2020

### DIFF
--- a/setup_files/raw_data_urls.txt
+++ b/setup_files/raw_data_urls.txt
@@ -58,6 +58,10 @@ https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2019-09.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2019-10.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2019-11.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2019-12.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2020-01.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2020-02.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2020-03.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhv_tripdata_2020-04.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-02.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-03.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-04.csv
@@ -69,6 +73,12 @@ https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-09.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-10.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-11.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2019-12.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-01.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-02.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-03.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-04.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-05.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/fhvhv_tripdata_2020-06.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2013-08.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2013-09.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2013-10.csv
@@ -146,6 +156,12 @@ https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-09.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-10.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-11.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2019-12.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-01.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-02.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-03.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-04.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-05.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/green_tripdata_2020-06.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2009-01.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2009-02.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2009-03.csv
@@ -278,3 +294,9 @@ https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-09.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-10.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-11.csv
 https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-12.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-01.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-02.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-03.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-04.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-05.csv
+https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-06.csv

--- a/tlc_statistics/import_statistics_data.rb
+++ b/tlc_statistics/import_statistics_data.rb
@@ -9,7 +9,7 @@ def parse_number(string)
 end
 
 # TLC monthly reports
-tlc_monthly_data_url = "https://www1.nyc.gov/assets/tlc/downloads/csv/data_reports_monthly_indicators.csv"
+tlc_monthly_data_url = "https://www1.nyc.gov/assets/tlc/downloads/csv/data_reports_monthly.csv"
 tlc_monthly_data = CSV.parse(RestClient.get(tlc_monthly_data_url).body)
 
 CSV.open("tlc_monthly_data.csv", "wb") do |csv|


### PR DESCRIPTION
Note that small FHV bases only have data through April 2020, but taxis and high-volume FHVs (Uber/Lyft) have data through June 2020